### PR TITLE
issue #31: Add "packagePath" setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ Settings available via user/workspace settings:
 	// Port to use for psc-ide
 	"purescript.pscIdePort": 4242,
 
+	// Location of installed packages
+	"purescript.packagePath": "Path to installed packages",
+
 	// Build command to use with arguments. Not passed to shell. eg `pulp build --json-errors`
 	"purescript.buildCommand": "pulp build --no-psa --json-errors"
 }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,11 @@
           "default": 4242,
           "description": "Port to use for psc-ide"
         },
+        "purescript.packagePath": {
+          "type": "string",
+          "default": "bower_components",
+          "description": "Path to installed packages"
+        },
         "purescript.buildCommand": {
           "type": "string",
           "default": "pulp build --no-psa --json-errors",

--- a/src/IdePurescript/VSCode/Main.purs
+++ b/src/IdePurescript/VSCode/Main.purs
@@ -104,7 +104,8 @@ startServer' :: forall eff eff'. String -> Int -> String -> Notify (P.ServerEff 
 startServer' server _port root cb = do
   config <- liftEff $ getConfiguration "purescript"
   useNpmPath <- liftEff $ either (const false) id <<< readBoolean <$> getValue config "addNpmPath"
-  P.startServer' root server useNpmPath ["src/**/*.purs", "bower_components/**/*.purs"] cb
+  packagePath <- liftEff $ either (const "bower_components") id <<< readString <$> getValue config "packagePath"
+  P.startServer' root server useNpmPath ["src/**/*.purs", packagePath <> "/**/*.purs"] cb
 
 toDiagnostic :: Boolean -> PscError -> FileDiagnostic
 toDiagnostic isError (PscError { message, filename, position, suggestion }) =


### PR DESCRIPTION
Addresses issue #31 

It looks like version 0.4.3 (the version published) isn't on github -- maybe you didn't push it after publishing? If so, I'm guessing this will probably merge ok with it anyway, but let me know if not. Also, 0.4.2 didn't quite work (even without my changes), so I tested by overlaying my compiled files over 0.4.3's installation.

FYI, using an override of:
```
  "purescript.packagePath": ".psc-package/psc-0.10.2"
```
(including the package set's subdir) seems a reasonable workaround to the active package set issue for now.
