### PR TITLE
spago documentation update and reorganization

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,19 @@ For `spago` with `psc-package`, add the following configuration to your `setting
 {
   "purescript.addSpagoSources": true,
   "purescript.addNpmPath": true,
-  "purescript.buildCommand": "spago build -- --json-errors"
+  "purescript.buildCommand": "spago build --purs-args --json-errors"
 }
 ```
 
+### Common Build Information
+
 Be sure to `Restart/Reconnect purs IDE server` following such changes.
 
-Error suggestions are provided for some compiler errors, try alt/cmd and `.`.
+A rebuild is automatically triggered when saving a `.purs` file.
+
+Note the following default vscode bindings for processing build errors:
+* `F8` cycles through errors.
+* `CTRL + .` or `CMD + .` shows suggested fixes. The compiler sometimes provides these suggestions.
 
 ## Autocomplete
 

--- a/README.md
+++ b/README.md
@@ -26,26 +26,16 @@ This package will launch a `purescript-language-server` process, which will auto
 
 Multi-root workspaces should be supported via a multiple language server approach.
 
-For all functions provided by the IDE server you will need to build your project first!
+For all functions provided by the IDE server you will need to build your project first! A rebuild is automatically triggered when saving a `.purs` file.
 
 The extension [language-purescript](https://marketplace.visualstudio.com/items/nwolverson.language-purescript)
 is required but should be installed automatically. The package will start on opening a `.purs` file.
 
-### Suggested extensions
-
-See [input-assist](https://github.com/freebroccolo/vscode-input-assist) for Unicode input assistance
-on autocomplete which is known to work with this extension, alternatively [unicode-latex](https://github.com/ojsheikh/unicode-latex)
-which offers similar LaTeX based input vi a lookup command.
-
-### Key bindings
-
-The only key binding supplied out of the box is Shift+Ctrl+B (or Shift+Cmd+B) for the full "Build" command. Although this is only enabled inside PureScript-language text editors, it does conflict with the built-in Build command. This can be edited, and other keybinds added, in the VS Code Keyboard Shortcuts preferences.
-
-## Build
+Be sure to `Restart/Reconnect purs IDE server` (accessed through `CTRL+SHIFT+P`/`CMD+SHIFT+P`) after following the below configuration steps for `pulp` or `spago`.
 
 ### With Pulp (default)
 
-'PureScript Build' command will build your project using the command line `pulp build -- --json-errors`.
+`PureScript: Build` command will build your project using the command line `pulp build -- --json-errors`.
 Version 0.8.0+ of the PureScript compiler is required, as well as version 10.0.0 of `pulp` (with earlier versions remove `--`).
 
 For `pulp` with `psc-package`, add the following configuration to your `settings.json`:
@@ -58,6 +48,8 @@ For `pulp` with `psc-package`, add the following configuration to your `settings
 
 ### With Spago
 
+Note that `--` was replaced by `--purs-args` in spago version `0.10.0.0`.
+
 For `spago` with `psc-package`, add the following configuration to your `settings.json`:
 ```
 {
@@ -67,15 +59,20 @@ For `spago` with `psc-package`, add the following configuration to your `setting
 }
 ```
 
-### Common Build Information
+### Suggested extensions
 
-Be sure to `Restart/Reconnect purs IDE server` following such changes.
+See [input-assist](https://github.com/freebroccolo/vscode-input-assist) for Unicode input assistance
+on autocomplete which is known to work with this extension, alternatively [unicode-latex](https://github.com/ojsheikh/unicode-latex)
+which offers similar LaTeX based input vi a lookup command.
 
-A rebuild is automatically triggered when saving a `.purs` file.
+### Key bindings
 
-Note the following default vscode bindings for processing build errors:
+The only key binding supplied out of the box is Shift+Ctrl+B (or Shift+Cmd+B) for the full "Build" command. Although this is only enabled inside PureScript-language text editors, it does conflict with the built-in Build command. This can be edited, and other keybinds added, in the VS Code Keyboard Shortcuts preferences.
+
+The following default vscode bindings are helpful for processing build errors:
 * `F8` cycles through errors.
 * `CTRL + .` or `CMD + .` shows suggested fixes. The compiler sometimes provides these suggestions.
+
 
 ## Autocomplete
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 This package provides editor support for PureScript projects in Visual Studio Code, similar to the corresponding
  [atom plugin](https://github.com/nwolverson/atom-ide-purescript). Now based on a common
- [PureScript language server](https://github.com/nwolverson/purescript-language-server)! Basic syntax highlighting support
- is provided by the separate package [language-purescript](https://marketplace.visualstudio.com/items/nwolverson.language-purescript) 
- which should be installed automatically as a dependency. 
+ [PureScript language server](https://github.com/nwolverson/purescript-language-server)! 
 
 This package provides:
 
@@ -15,23 +13,19 @@ This package provides:
 - [x] Go to symbol
 - [x] Go to definition
 
-Package should trigger on opening a `.purs` file.
+The extension [language-purescript](https://marketplace.visualstudio.com/items/nwolverson.language-purescript) provides basic syntax highlighting support - it is required but should be installed automatically as a dependency. This package will start on opening a `.purs` file, and automatically trigger a rebuild on saving a `.purs` file.
 
 ## Installation and General Use
 
 This package makes use of the [`purs ide server`](https://github.com/purescript/purescript/tree/master/psc-ide) (previously `psc-ide`) for most functionality, with `purs compile` (by default via `pulp`) for the explicit
-build command. All this is via a Language Server Protocol implementation, [purescript-language-server](https://github.com/nwolverson/purescript-language-server).
+build command. All this is via a Language Server Protocol implementation, [purescript-language-server](https://github.com/nwolverson/purescript-language-server). Multi-root workspaces should be supported via a multiple language server approach.
 
 This package will launch a `purescript-language-server` process, which will automatically (but this is configurable) start `purs ide server` in your project directory and kill it when closing. Start/stop and restart commands are provided for the IDE server in case required (eg after changing config or updating compiler version).
 
-Multi-root workspaces should be supported via a multiple language server approach.
+For all functions provided by the IDE server you will need to build your project first! This can either be via the built-in
+build command, or via an external tool - but if you do build externally, you should be sure to `Restart/Reconnect purs IDE server` (accessed through `CTRL+SHIFT+P`/`CMD+SHIFT+P`) afterwards, or the IDE server will not be able to pick up any changes.
 
-For all functions provided by the IDE server you will need to build your project first! A rebuild is automatically triggered when saving a `.purs` file.
-
-The extension [language-purescript](https://marketplace.visualstudio.com/items/nwolverson.language-purescript)
-is required but should be installed automatically. The package will start on opening a `.purs` file.
-
-Be sure to `Restart/Reconnect purs IDE server` (accessed through `CTRL+SHIFT+P`/`CMD+SHIFT+P`) after following the below configuration steps for `pulp` or `spago`.
+You can configure building with `pulp` (optionally with `psc-package`) or `spago` by following the below configuration steps, after which you should also `Restart/Reconnect purs IDE server`.
 
 ### With Pulp (default)
 


### PR DESCRIPTION
I split this into two commits to hopefully make the changes easier to follow.

A version bump would be helpful for documentation changes so they appear within vscode. I spent some time trying to get `spago` builds working, before realizing that more detailed instructions were available in this repo's readme.