### PR TITLE
Moved 'input-assist' from repo 'freebroccolo'

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For `spago` with `psc-package`, add the following configuration to your `setting
 
 ### Suggested extensions
 
-See [input-assist](https://github.com/freebroccolo/vscode-input-assist) for Unicode input assistance
+See [input-assist](https://github.com/darinmorrison/vscode-input-assist) for Unicode input assistance
 on autocomplete which is known to work with this extension, alternatively [unicode-latex](https://github.com/ojsheikh/unicode-latex)
 which offers similar LaTeX based input vi a lookup command.
 


### PR DESCRIPTION
I was noticing that the link for [input-assist](https://github.com/freebroccolo/vscode-input-assist) on the README was broken.  So I looked for it elsewhere and found the most likely candidate was [here](https://github.com/darinmorrison/vscode-input-assist).

I hope this is the appropriate new link.