### PR TITLE
Add the qualifier to the import args

### DIFF
--- a/src/IdePurescript/VSCode/Imports.purs
+++ b/src/IdePurescript/VSCode/Imports.purs
@@ -51,8 +51,10 @@ addModuleImport client = launchAffAndRaise $ void $ do
       -> do
         pick <- showQuickPick modules
         uri <- liftEffect $ filenameToUri =<< (getPath $ getDocument ed)
+        atCursor <- liftEffect $ identifierAtCursor ed
+        qual <- pure $ toNullable $ _.qualifier =<< atCursor
         case pick of
           Just modName -> void $ sendCommand client (cmdName addModuleImportCmd)
-            (toNullable $ Just [ unsafeToForeign modName, unsafeToForeign $ toNullable Nothing, unsafeToForeign uri ])
+            (toNullable $ Just [ unsafeToForeign modName, unsafeToForeign qual, unsafeToForeign uri ])
           _ -> pure unit
     _, _ -> pure unit

--- a/src/IdePurescript/VSCode/Imports.purs
+++ b/src/IdePurescript/VSCode/Imports.purs
@@ -53,8 +53,9 @@ addModuleImport client = launchAffAndRaise $ void $ do
         uri <- liftEffect $ filenameToUri =<< (getPath $ getDocument ed)
         atCursor <- liftEffect $ identifierAtCursor ed
         qual <- pure $ toNullable $ _.qualifier =<< atCursor
+        ident <- pure $ toNullable $ map _.word $ atCursor
         case pick of
           Just modName -> void $ sendCommand client (cmdName addModuleImportCmd)
-            (toNullable $ Just [ unsafeToForeign modName, unsafeToForeign qual, unsafeToForeign uri ])
+            (toNullable $ Just [ unsafeToForeign modName, unsafeToForeign qual, unsafeToForeign ident, unsafeToForeign uri ])
           _ -> pure unit
     _, _ -> pure unit

--- a/src/IdePurescript/VSCode/Imports.purs
+++ b/src/IdePurescript/VSCode/Imports.purs
@@ -53,9 +53,8 @@ addModuleImport client = launchAffAndRaise $ void $ do
         uri <- liftEffect $ filenameToUri =<< (getPath $ getDocument ed)
         atCursor <- liftEffect $ identifierAtCursor ed
         qual <- pure $ toNullable $ _.qualifier =<< atCursor
-        ident <- pure $ toNullable $ map _.word $ atCursor
         case pick of
           Just modName -> void $ sendCommand client (cmdName addModuleImportCmd)
-            (toNullable $ Just [ unsafeToForeign modName, unsafeToForeign qual, unsafeToForeign ident, unsafeToForeign uri ])
+            (toNullable $ Just [ unsafeToForeign modName, unsafeToForeign qual, unsafeToForeign uri ])
           _ -> pure unit
     _, _ -> pure unit


### PR DESCRIPTION
I notice that manually invoking the command `Add Import` doesn't work for qualified imports the way emacs' psc-ide equivalent does. It looks like there was some intent to have qualified imports work since we read in the `qual` variable from the args in the backend. Since the info is already available, we pull the in the qualifier from `atCursor` and pass it through to the args so it can be processed from the purescript-language-server backend.

I have a corresponding PR I can make soon on the backend side of this, although that change is not quite as pretty, but hopefully this looks ok to you!