### PR TITLE
Replace quotes in scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -305,8 +305,8 @@
         ]
     },
     "scripts": {
-        "vscode:prepublish": "run-s prep tsc:* purs:* 'bundle:* -- --minify'",
-        "build": "run-s prep tsc:* purs:* 'bundle:* -- --sourcemap'",
+        "vscode:prepublish": "run-s prep tsc:* purs:* \"bundle:* -- --minify\"",
+        "build": "run-s prep tsc:* purs:* \"bundle:* -- --sourcemap\"",
         "prep": "mkdirp out/src dist",
         "tsc:ffi": "tsc -p src/VSCode/",
         "tsc:extension": "tsc -p ./",


### PR DESCRIPTION
Replace quotes in scripts  to make Windows cmd compatible.