### PR TITLE
Default to purs-tidy formatter

### DIFF
--- a/package.json
+++ b/package.json
@@ -273,7 +273,7 @@
                         "Use purs-tidy. Must be installed - [instructions](https://github.com/natefaubion/purescript-tidy)",
                         "Use pose (prettier plugin). Must be installed - [instructions](https://pose.rowtype.yoga/)"
                     ],
-                    "default": "purty",
+                    "default": "purs-tidy",
                     "description": "Tool to use to for formatting. Must be installed and on PATH (or npm installed with addNpmPath set)"
                 },
                 "purescript.declarationTypeCodeLens": {


### PR DESCRIPTION
The purs-tidy formatter has become the most popular and the closest to a "standard" formatter as far as I can tell, and is compatible with PureScript 0.14 and PureScript 0.15 (unlike purty). For this reason, I think it should be the default option in the formatters list.