### PR TITLE
Add basic support for multi root projects in monorepos

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,181 +3,183 @@ import { CloseAction, ErrorAction, ExecuteCommandRequest, LanguageClient, Langua
 import { setDiagnosticsBegin, setDiagnosticsEnd, setCleanBegin, setCleanEnd, diagnosticsBegin, diagnosticsEnd, cleanBegin, cleanEnd } from './notifications';
 import { registerMiddleware, unregisterMiddleware, middleware } from './middleware';
 import * as path from 'path';
-type ExtensionCommands = {[cmd: string]: (args: any[]) => void };
+type ExtensionCommands = { [cmd: string]: (args: any[]) => void };
 
 const clients: Map<string, LanguageClient> = new Map();
 const commandCode: Map<string, ExtensionCommands> = new Map();
 
 export function activate(context: ExtensionContext) {
-    const activatePS = require('../../output/Main').main;
+  const activatePS = require('../../output/Main').main;
 
-    // const module = require.resolve('purescript-language-server');
+  // const module = require.resolve('purescript-language-server');
 
-    const module = path.join(context.extensionPath, 'dist', 'server.js');
-    
-    const opts = { module, transport: TransportKind.ipc };
-    const serverOptions: ServerOptions =
-        {
-            run: opts,
-            debug: { ...opts, options: {
-                execArgv: [
-                    "--nolazy",
-                    "--inspect=6009"
-                ]
-            }}
-        }
-    const output = window.createOutputChannel("IDE PureScript");
-    // Options to control the language client
-    const clientOptions = (folder: WorkspaceFolder): LanguageClientOptions => ({
-        // Register for PureScript and JavaScript documents in the given root folder
-        documentSelector: [
-            { scheme: 'file', language: 'purescript', pattern: `${folder.uri.fsPath}/**/*` },
-            { scheme: 'file', language: 'javascript', pattern: `${folder.uri.fsPath}/**/*` },
-            ...folder.index === 0 ? [ { scheme: 'untitled', language: 'purescript' } ] : []
-        ],
-        workspaceFolder: folder,
-        synchronize: {
-            configurationSection: 'purescript',
-            fileEvents:
-                [ workspace.createFileSystemWatcher('**/*.purs')
-                , workspace.createFileSystemWatcher('**/*.js')
-                ]
-        },
-        outputChannel: output,
-        revealOutputChannelOn: RevealOutputChannelOn.Never,
-        errorHandler: { 
-            error: (e,m,c) => { console.error(e,m,c); return { action: ErrorAction.Continue }  },
-            closed: () => ({ action: CloseAction.DoNotRestart })
-        },
-        initializationOptions: {
-            executeCommandProvider: false
-        },
-        middleware
+  const module = path.join(context.extensionPath, 'dist', 'server.js');
+
+  const opts = { module, transport: TransportKind.ipc };
+  const serverOptions: ServerOptions =
+  {
+    run: opts,
+    debug: {
+      ...opts, options: {
+        execArgv: [
+          "--nolazy",
+          "--inspect=6009"
+        ]
+      }
+    }
+  }
+  const output = window.createOutputChannel("IDE PureScript");
+  // Options to control the language client
+  const clientOptions = (folder: WorkspaceFolder): LanguageClientOptions => ({
+    // Register for PureScript and JavaScript documents in the given root folder
+    documentSelector: [
+      { scheme: 'file', language: 'purescript', pattern: `${folder.uri.fsPath}/**/*` },
+      { scheme: 'file', language: 'javascript', pattern: `${folder.uri.fsPath}/**/*` },
+      ...folder.index === 0 ? [{ scheme: 'untitled', language: 'purescript' }] : []
+    ],
+    workspaceFolder: folder,
+    synchronize: {
+      configurationSection: 'purescript',
+      fileEvents:
+        [workspace.createFileSystemWatcher('**/*.purs')
+          , workspace.createFileSystemWatcher('**/*.js')
+        ]
+    },
+    outputChannel: output,
+    revealOutputChannelOn: RevealOutputChannelOn.Never,
+    errorHandler: {
+      error: (e, m, c) => { console.error(e, m, c); return { action: ErrorAction.Continue } },
+      closed: () => ({ action: CloseAction.DoNotRestart })
+    },
+    initializationOptions: {
+      executeCommandProvider: false
+    },
+    middleware
+  });
+
+  let commandNames: string[] = [
+    "caseSplit-explicit",
+    "addClause-explicit",
+    "addCompletionImport",
+    "addModuleImport",
+    "replaceSuggestion",
+    "replaceAllSuggestions",
+    "build",
+    "clean",
+    "typedHole-explicit",
+    "startPscIde",
+    "stopPscIde",
+    "restartPscIde",
+    "getAvailableModules",
+    "search",
+    "fixTypo",
+    "sortImports"
+  ].map(x => `purescript.${x}`);
+
+  const getWorkspaceFolder = (doc: TextDocument) => {
+    if (doc.uri.scheme === 'file') {
+      const wf = workspace.getWorkspaceFolder(doc.uri);
+      if (wf) {
+        return wf;
+      }
+    }
+    if (workspace.workspaceFolders && workspace.workspaceFolders.length > 0) {
+      return workspace.workspaceFolders[0];
+    }
+    return null;
+  }
+
+  commandNames.forEach(command => {
+    commands.registerTextEditorCommand(command, (ed, edit, ...args) => {
+      const wf = getWorkspaceFolder(ed.document);
+      if (!wf) { return; }
+      const lc = clients.get(wf.uri.toString());
+      if (!lc) {
+        output.appendLine("Didn't find language client for " + ed.document.uri);
+        return;
+      }
+      lc.sendRequest(ExecuteCommandRequest.type, { command, arguments: args });
     });
+  })
 
-    let commandNames: string[] = [
-        "caseSplit-explicit",
-        "addClause-explicit",
-        "addCompletionImport",
-        "addModuleImport",
-        "replaceSuggestion",
-        "replaceAllSuggestions",
-        "build",
-        "clean",
-        "typedHole-explicit",
-        "startPscIde",
-        "stopPscIde",
-        "restartPscIde",
-        "getAvailableModules",
-        "search",
-        "fixTypo",
-        "sortImports"
-    ].map(x => `purescript.${x}`);
+  const extensionCmd = (cmdName: string) => (ed, edit, ...args) => {
+    const wf = getWorkspaceFolder(ed.document);
+    if (!wf) { return; }
+    const cmds = commandCode.get(wf.uri.toString());
+    if (!cmds) {
+      output.appendLine("Didn't find language client for " + ed.document.uri);
+      return;
+    }
+    cmds[cmdName](args);
+  }
 
-    const getWorkspaceFolder = (doc: TextDocument) => {
-        if (doc.uri.scheme === 'file') {
-            const wf = workspace.getWorkspaceFolder(doc.uri);
-            if (wf) {
-                return wf;
+  function addClient(folder: WorkspaceFolder) {
+    if (!clients.has(folder.uri.toString())) {
+      try {
+        output.appendLine("Launching new language client for " + folder.uri.toString());
+        const client = new LanguageClient('purescript', 'IDE PureScript', serverOptions, clientOptions(folder));
+
+        client.onReady().then(async () => {
+          output.appendLine("Activated lc for " + folder.uri.toString());
+          const cmds: ExtensionCommands = activatePS({ diagnosticsBegin, diagnosticsEnd, cleanBegin, cleanEnd }, client);
+          const cmdNames = await commands.getCommands();
+          commandCode.set(folder.uri.toString(), cmds);
+          Promise.all(Object.keys(cmds).map(async cmd => {
+            if (cmdNames.indexOf(cmd) === -1) {
+              commands.registerTextEditorCommand(cmd, extensionCmd(cmd));
             }
-        }
-        if (workspace.workspaceFolders && workspace.workspaceFolders.length > 0) {
-            return workspace.workspaceFolders[0];
-        }
-        return null;
+          }));
+        }).catch(err => output.appendLine(err));
+
+        client.start();
+        clients.set(folder.uri.toString(), client);
+      } catch (e) {
+        output.appendLine(e);
+      }
+    }
+  }
+
+  function didOpenTextDocument(document: TextDocument): void {
+    if ((!['purescript', 'javascript'].includes(document.languageId)) || document.uri.scheme !== 'file') {
+      return;
     }
 
-    commandNames.forEach(command => {
-        commands.registerTextEditorCommand(command, (ed, edit, ...args) => {
-            const wf = getWorkspaceFolder(ed.document);
-            if (!wf) { return; }
-            const lc = clients.get(wf.uri.toString());
-            if (!lc) {
-                output.appendLine("Didn't find language client for " + ed.document.uri);
-                return;
-            }
-            lc.sendRequest(ExecuteCommandRequest.type, { command, arguments: args });
-        });
-    })
-
-    const extensionCmd = (cmdName: string) => (ed, edit, ...args) => {
-        const wf = getWorkspaceFolder(ed.document);
-        if (!wf) { return; }
-        const cmds = commandCode.get(wf.uri.toString());
-        if (!cmds) {
-            output.appendLine("Didn't find language client for " + ed.document.uri);
-            return;
-        }
-        cmds[cmdName](args);
+    const folder = workspace.getWorkspaceFolder(document.uri);
+    if (!folder) {
+      output.appendLine("Didn't find workspace folder for " + document.uri);
+      return;
     }
+    addClient(folder);
+  }
 
-    function addClient(folder: WorkspaceFolder) {
-        if (!clients.has(folder.uri.toString())) {
-            try {
-                output.appendLine("Launching new language client for " + folder.uri.toString());
-                const client = new LanguageClient('purescript', 'IDE PureScript', serverOptions, clientOptions(folder));
-            
-                client.onReady().then(async () => {
-                    output.appendLine("Activated lc for "+ folder.uri.toString());
-                    const cmds: ExtensionCommands = activatePS({ diagnosticsBegin, diagnosticsEnd, cleanBegin, cleanEnd }, client);
-                    const cmdNames = await commands.getCommands();
-                    commandCode.set(folder.uri.toString(), cmds);
-                    Promise.all(Object.keys(cmds).map(async cmd => {
-                        if (cmdNames.indexOf(cmd) === -1) {
-                            commands.registerTextEditorCommand(cmd, extensionCmd(cmd));
-                        }
-                    }));
-                }).catch(err => output.appendLine(err));
-
-                client.start();
-                clients.set(folder.uri.toString(), client);
-            } catch (e) {
-                output.appendLine(e);
-            }
-        }
+  workspace.onDidOpenTextDocument(didOpenTextDocument);
+  workspace.textDocuments.forEach(didOpenTextDocument);
+  workspace.onDidChangeWorkspaceFolders((event) => {
+    for (const folder of event.removed) {
+      const client = clients.get(folder.uri.toString());
+      if (client) {
+        clients.delete(folder.uri.toString());
+        client.stop();
+      }
     }
-
-    function didOpenTextDocument(document: TextDocument): void {
-        if ((! ['purescript', 'javascript'].includes(document.languageId)) || document.uri.scheme !== 'file') {
-            return;
-        }
-
-        const folder = workspace.getWorkspaceFolder(document.uri);
-        if (!folder) {
-            output.appendLine("Didn't find workspace folder for " + document.uri);
-            return;
-        }
-        addClient(folder);
+  });
+  if (clients.size == 0) {
+    if (workspace.workspaceFolders && workspace.workspaceFolders.length == 1) {
+      output.appendLine("Only one folder in workspace, starting language server");
+      // The extension must be activated because there are Purs files in there
+      addClient(workspace.workspaceFolders[0]);
+    } else if (workspace.workspaceFolders && workspace.workspaceFolders.length > 1) {
+      output.appendLine("More than one folder in workspace, open a PureScript file to start language server");
+    } else if (!workspace.workspaceFolders) {
+      output.appendLine("It looks like you've started VS Code without specifying a folder, ie from a language extension development environment. Open a PureScript file to start language server.");
     }
-
-    workspace.onDidOpenTextDocument(didOpenTextDocument);
-    workspace.textDocuments.forEach(didOpenTextDocument);
-    workspace.onDidChangeWorkspaceFolders((event) => {
-        for (const folder of event.removed) {
-            const client = clients.get(folder.uri.toString());
-            if (client) {
-                clients.delete(folder.uri.toString());
-                client.stop();
-            }
-        }
-    });
-    if (clients.size == 0) {
-        if (workspace.workspaceFolders && workspace.workspaceFolders.length == 1) {
-            output.appendLine("Only one folder in workspace, starting language server");
-            // The extension must be activated because there are Purs files in there
-            addClient(workspace.workspaceFolders[0]);
-        } else if (workspace.workspaceFolders && workspace.workspaceFolders.length > 1) {
-            output.appendLine("More than one folder in workspace, open a PureScript file to start language server");
-        } else if (!workspace.workspaceFolders) {
-            output.appendLine("It looks like you've started VS Code without specifying a folder, ie from a language extension development environment. Open a PureScript file to start language server.");
-        }
-    }
-    return { registerMiddleware, unregisterMiddleware, setDiagnosticsBegin, setDiagnosticsEnd, setCleanBegin, setCleanEnd }
+  }
+  return { registerMiddleware, unregisterMiddleware, setDiagnosticsBegin, setDiagnosticsEnd, setCleanBegin, setCleanEnd }
 }
 export function deactivate(): Thenable<void> {
-	let promises: Thenable<void>[] = [];
-	for (let client of Array.from(clients.values())) {
-		promises.push(client.stop());
-	}
-	return Promise.all(promises).then(() => undefined);
+  let promises: Thenable<void>[] = [];
+  for (let client of Array.from(clients.values())) {
+    promises.push(client.stop());
+  }
+  return Promise.all(promises).then(() => undefined);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -81,7 +81,7 @@ export function activate(context: ExtensionContext) {
   ].map(x => `purescript.${x}`);
 
   const getProjectRootForDocument = (doc: TextDocument) => {
-    if (doc.uri.scheme === 'file') {
+    if (doc.uri.scheme === 'file' && doc.uri.fsPath.endsWith('.purs')) {
       return getProjectRoot(output, doc.uri)
     }
     return null;


### PR DESCRIPTION
This PR enables having multiple PureScript projects in multiple sub-folders in a monorepo.

It defaults back to using the workspace as root if no other root is found.